### PR TITLE
fix(ci): use golangci/golangci-lint-action instead of curl install

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,23 +22,9 @@ jobs:
         with:
           go-version: '1.26.2'
 
-      - name: Setup GoLangCI-Lint
-        run: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s 
+      - uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
 
-      - name: Show GoLangCI-Lint version
-        run: ./bin/golangci-lint --version | head -n1
-
-      - name: Run GoLangCI-Lint
-        run: >
-          github-comment exec --token ${{ secrets.GITHUB_TOKEN }} --
-          ./bin/golangci-lint run
-        working-directory: ./
-
-      - name: Hide old comment
-        run: github-comment hide --token ${{ secrets.GITHUB_TOKEN }}
-        if: ${{ github.event_name == 'pull_request' || ( github.event_name == 'push' && github.ref_name != 'main' ) }}
-
-      - name: Build 
+      - name: Build
         run: go build
         working-directory: ./
  


### PR DESCRIPTION
## Summary

- `curl` スクリプトによる golangci-lint インストールがチェックサム検証エラーで失敗する問題を修正
- 公式 Action `golangci/golangci-lint-action@v9.2.0` に置き換え
- `github-comment` による PR コメント投稿ステップも不要になるため削除（GitHub Annotations で直接表示される）

## 背景

全 PR の `build_and_test` CI が以下のエラーで失敗していた:

```
golangci-lint err hash_sha256_verify checksum for 'golangci-lint-2.12.2-linux-amd64.tar.gz' did not verify
```

同じ問題が別リポジトリ（hasher）の PR #367 で修正済みのため、同等の対応を適用。

## Test plan

- [ ] CI の `build_and_test` ジョブが pass することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)